### PR TITLE
fix: error spams until your server storage is full due to logs

### DIFF
--- a/source/SLAYER_AntiCamp/SLAYER_AntiCamp.cs
+++ b/source/SLAYER_AntiCamp/SLAYER_AntiCamp.cs
@@ -519,7 +519,7 @@ public class SLAYER_AntiCamp : BasePlugin, IPluginConfig<SLAYER_AntiCampConfig>
     }
     public void TeleportLaser(CBeam? laser,Vector start, Vector end)
     {
-        if(laser == null && !laser.IsValid)return;
+        if(laser == null || !laser.IsValid) return;
         // set pos
         laser.Teleport(start, RotationZero, VectorZero);
         // end pos


### PR DESCRIPTION
`08:08:19 [EROR] (cssharp:Core) Error invoking callback
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Entity is not valid
   at CounterStrikeSharp.API.Core.CBaseEntity.Teleport(Vector position, QAngle angles, Vector velocity) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs:line 14
   at SLAYER_AntiCamp.SLAYER_AntiCamp.TeleportLaser(CBeam laser, Vector start, Vector end)
   at SLAYER_AntiCamp.SLAYER_AntiCamp.<>c__DisplayClass41_0.<DrawBeaconOnPlayer>b__0()
   at InvokeStub_Action.Invoke(Object, Object, IntPtr*)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at CounterStrikeSharp.API.Core.FunctionReference.<CreateWrappedCallback>b__18_0(fxScriptContext* context) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/FunctionReference.cs:line 100`